### PR TITLE
Wrong size used to update block replicas

### DIFF
--- a/lib/common/interface/mysqlstore.py
+++ b/lib/common/interface/mysqlstore.py
@@ -457,7 +457,7 @@ class MySQLStore(LocalStoreInterface):
                         id_group_map[group_id],
                         b_is_complete,
                         b_is_custodial,
-                        size = block.size,
+                        size = br_size,
                         last_update = br_last_update
                     )
 


### PR DESCRIPTION
Wrong values were used to update incomplete block replicas when performing the delta update. This caused sites to show a higher occupancy than they actually have.