### PR TITLE
Updating (disowning) block replicas

### DIFF
--- a/lib/common/interface/mysqlstore.py
+++ b/lib/common/interface/mysqlstore.py
@@ -1252,7 +1252,7 @@ class MySQLStore(LocalStoreInterface):
 
         all_replicas = []
         for replica in replica_list:
-            all_replicas.append((block_name_to_id[replica.block.name], site_id_map[replica.site], group_id_map[replica.group] if replica.group != None else None, replica.is_complete, replica.is_custodial, time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(block_replica.last_update))))
+            all_replicas.append((block_name_to_id[replica.block.name], site_id_map[replica.site], group_id_map[replica.group], replica.is_complete, replica.is_custodial, time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(block_replica.last_update))))
 
         fields = ('block_id', 'site_id', 'group_id', 'is_complete', 'is_custodial', 'last_update')
         self._mysql.insert_many('block_replicas', fields, None, all_replicas, do_update = True)

--- a/lib/common/interface/store.py
+++ b/lib/common/interface/store.py
@@ -558,6 +558,32 @@ class LocalStoreInterface(object):
         finally:
             self.release_lock()
 
+    def update_blockreplica(self, replica):
+        """
+        Update block replica in persistent storage.
+        """
+
+        if config.read_only:
+            logger.debug('_do_update_blockreplica(%s:%s)', replica.site.name, replica.block.real_name())
+            return
+
+        self.update_blockreplicas([replica])
+
+    def update_blockreplicas(self, replica_list):
+        """
+        Update a set of block replicas in persistent storage.
+        """
+
+        if config.read_only:
+            logger.debug('_do_update_blockreplicas(%d replicas)', len(replica_list))
+            return
+
+        self.acquire_lock()
+        try:
+            self._do_update_blockreplicas(replica_list)
+        finally:
+            self.release_lock()
+
     def set_dataset_status(self, dataset, status):
         """
         Set and save dataset status

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -499,7 +499,7 @@ class Detox(object):
                             block_replica.block,
                             block_replica.site,
                             None,
-                            block_replicais_complete,
+                            block_replica.is_complete,
                             block_replica.is_custodial,
                             size = block_replica.size,
                             last_update = block_replica.last_update)

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -494,16 +494,7 @@ class Detox(object):
                 for replica in replicas:
                     blockreplicas = []
                     for block_replica in replica.block_replicas:
-
-                        blockreplica = BlockReplica(
-                            block_replica.block,
-                            block_replica.site,
-                            None,
-                            block_replica.is_complete,
-                            block_replica.is_custodial,
-                            size = block_replica.size,
-                            last_update = block_replica.last_update)
-                        
+                        blockreplica = block_replica.clone(group = None)
                         blockreplicas.append(blockreplica)
                          
                     self.inventory_manager.store.update_blockreplicas(blockreplicas)

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -494,7 +494,6 @@ class Detox(object):
                 for replica in replicas:
                     blockreplicas = []
                     for block_replica in replica.block_replicas:
-                        block_replica.group = None
 
                         blockreplica = BlockReplica(
                             block_replica.block,

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -491,6 +491,23 @@ class Detox(object):
 
             for deletion_id, (approved, replicas) in deletion_mapping.iteritems():
                 size = sum([r.size() for r in replicas])
+                for replica in replicas:
+                    blockreplicas = []
+                    for block_replica in replica.block_replicas:
+                        block_replica.group = None
+
+                        blockreplica = BlockReplica(
+                            block_replica.block,
+                            block_replica.site,
+                            None,
+                            block_replicais_complete,
+                            block_replica.is_custodial,
+                            size = block_replica.size,
+                            last_update = block_replica.last_update)
+                        
+                        blockreplicas.append(blockreplica)
+                         
+                    self.inventory_manager.store.update_blockreplicas(blockreplicas)
 
                 if approved and not is_test:
                     total_size += size


### PR DESCRIPTION
A function is needed to update block replicas in the database on disk. Specifically, this came up when dealing with having to disown block replicas if a dataset replica was decided to be deleted. The actual deletion of the block replica will then be picked up by the deletions query in the delta update.