### PR TITLE
Two bugfixes

### DIFF
--- a/lib/common/interface/mysqlhistory.py
+++ b/lib/common/interface/mysqlhistory.py
@@ -634,3 +634,5 @@ class MySQLHistory(TransactionHistoryInterface):
 
         self._cache_db.query('DELETE FROM `replica_snapshot_usage` WHERE `timestamp` < DATE_SUB(NOW(), INTERVAL 1 WEEK)')
         self._cache_db.query('OPTIMIZE TABLE `replica_snapshot_usage`')
+        self._cache_db.query('DELETE FROM `site_snapshot_usage` WHERE `timestamp` < DATE_SUB(NOW(), INTERVAL 1 WEEK)')
+        self._cache_db.query('OPTIMIZE TABLE `site_snapshot_usage`')

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -151,7 +151,7 @@ class Detox(object):
                         block_replicas -= set(action.block_replicas)
     
                     elif isinstance(action, DeleteBlock):
-                        unlinked_replicas, reowned_replicas = self.unlink_block_replicas(replica, action.block_replicas)
+                        unlinked_replicas, reowned_replicas = self.unlink_block_replicas(replica, action.block_replicas, policy, is_test)
                         if len(unlinked_replicas) != 0:
                             deleted[replica].append((unlinked_replicas, condition_id))
 
@@ -175,7 +175,7 @@ class Detox(object):
                         protect_candidates[replica].append((list(block_replicas), condition_id))
     
                     elif isinstance(action, Delete):
-                        unlinked_replicas, reowned_replicas = self.unlink_block_replicas(replica, block_replicas)
+                        unlinked_replicas, reowned_replicas = self.unlink_block_replicas(replica, block_replicas, policy, is_test)
                         if len(unlinked_replicas) != 0:
                             deleted[replica].append((unlinked_replicas, condition_id))
 
@@ -249,7 +249,7 @@ class Detox(object):
     
                     for match in matches:
                         # match = ([block_replica], condition_id)
-                        unlinked_replicas, _ = self.unlink_block_replicas(replica, match[0])
+                        unlinked_replicas, _ = self.unlink_block_replicas(replica, match[0], policy, is_test)
                         if len(unlinked_replicas) != 0:
                             deleted_volume[site] += sum(br.size for br in unlinked_replicas)
                             deleted[replica].append((unlinked_replicas, match[1]))
@@ -337,7 +337,7 @@ class Detox(object):
 
         self.history.close_deletion_run(run_number)
 
-    def unlink_block_replicas(self, replica, block_replicas):
+    def unlink_block_replicas(self, replica, block_replicas, policy, is_test):
         """
         Unlink the dataset replica or parts of it from the owning containers.
         Return the list of unlinked block replicas and reowned block replicas.
@@ -384,6 +384,8 @@ class Detox(object):
                 logger.debug('%d blocks to hand over to %s', len(blocks_to_hand_over), dr_owner.name)
                 # not ideal to make reassignments here, but this operation affects later iterations
                 reassigned_blocks = self.reassign_owner(replica, blocks_to_hand_over, dr_owner, policy.partition, is_test)
+            else:
+                reassigned_blocks = []
 
             if len(blocks_to_unlink) != 0:
                 logger.debug('%d blocks to unlink', len(blocks_to_unlink))

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -113,57 +113,6 @@ class Detox(object):
         deleted = collections.defaultdict(list) # same
         kept = collections.defaultdict(list) # same
 
-        def unlink_block_replicas(replica, block_replicas):
-            """Unlink the dataset replica or parts of it from the owning containers and return the list of unlinked block replicas."""
-
-            if len(block_replicas) == len(replica.block_replicas):
-                for block_replica in block_replicas:
-                    block_replica.unlink()
-
-                replica.unlink()
-
-                return block_replicas
-
-            else:
-                # Special operation - if we are deleting block replicas owned by group B, whose
-                # ownership level (see dataformats/group) is Block, but the block replicas belong
-                # to a dataset replica otherwise owned by group D, whose ownership level is Dataset,
-                # then we don't delete the block replicas but hand them over to D.
-    
-                # establish a dataset-level owner
-                dr_owner = None
-                for block_replica in replica.block_replicas:
-                    if block_replica.group.olevel is Dataset:
-                        # there is a dataset-level owner
-                        dr_owner = block_replica.group
-                        break
-    
-                if dr_owner is None:
-                    blocks_to_hand_over = []
-                    blocks_to_unlink = list(block_replicas)
-                else:
-                    blocks_to_hand_over = []
-                    blocks_to_unlink = []
-                    for block_replica in block_replicas:
-                        if block_replica.group.olevel is Dataset:
-                            blocks_to_unlink.append(block_replica)
-                        else:
-                            blocks_to_hand_over.append(block_replica)
-    
-                if len(blocks_to_hand_over) != 0:
-                    logger.debug('%d blocks to hand over to %s', len(blocks_to_hand_over), dr_owner.name)
-                    # not ideal to make reassignments here, but this operation affects later iterations
-                    self.reassign_owner(replica, blocks_to_hand_over, dr_owner, policy.partition, is_test)
-
-                if len(blocks_to_unlink) != 0:
-                    logger.debug('%d blocks to unlink', len(blocks_to_unlink))
-    
-                    for block_replica in blocks_to_unlink:
-                        block_replica.unlink()
-
-                return blocks_to_unlink
-
-
         iteration = 0
 
         # now iterate through deletions, updating site usage as we go
@@ -202,11 +151,17 @@ class Detox(object):
                         block_replicas -= set(action.block_replicas)
     
                     elif isinstance(action, DeleteBlock):
-                        unlinked_replicas = unlink_block_replicas(replica, action.block_replicas)
+                        unlinked_replicas, reowned_replicas = self.unlink_block_replicas(replica, action.block_replicas)
                         if len(unlinked_replicas) != 0:
                             deleted[replica].append((unlinked_replicas, condition_id))
 
                             block_replicas -= set(unlinked_replicas)
+
+                        # need to swap out block replicas with groups reassigned because blockreplica is immutable
+                        for new_replica in reowned_replicas:
+                            old_replica = next(r for r in block_replicas if r.block == new_replica.block)
+                            block_replicas.remove(old_replica)
+                            block_replicas.add(new_replica)
 
                     elif isinstance(action, DismissBlock):
                         if replica.site in triggered_sites:
@@ -220,7 +175,7 @@ class Detox(object):
                         protect_candidates[replica].append((list(block_replicas), condition_id))
     
                     elif isinstance(action, Delete):
-                        unlinked_replicas = unlink_block_replicas(replica, block_replicas)
+                        unlinked_replicas, reowned_replicas = self.unlink_block_replicas(replica, block_replicas)
                         if len(unlinked_replicas) != 0:
                             deleted[replica].append((unlinked_replicas, condition_id))
 
@@ -228,6 +183,9 @@ class Detox(object):
                             # if all blocks were deleted, take the replica off all_replicas for later iterations
                             # this is the only place where the replica can become empty
                             empty_replicas.append(replica)
+
+                        # no need to update block_replicas set with reassigned blockreplicas because we don't
+                        # need it any more
     
                     elif isinstance(action, Dismiss):
                         if replica.site in triggered_sites:
@@ -268,6 +226,7 @@ class Detox(object):
                 for replica in replicas_to_delete:
                     site = replica.site
 
+                    # has the site reached the stop-deletion threshold?
                     offtrigger = False
                     for cond in policy.stop_condition:
                         if cond.match(site):
@@ -278,7 +237,8 @@ class Detox(object):
                         continue
     
                     quota = quotas[site] * 1.e+12
-    
+
+                    # have we deleted more than allowed in a single iteration?
                     if quota > 0. and deleted_volume[site] / quota > detox_config.main.deletion_per_iteration:
                         continue
     
@@ -288,7 +248,8 @@ class Detox(object):
                     matches = delete_candidates.pop(replica)
     
                     for match in matches:
-                        unlinked_replicas = unlink_block_replicas(replica, match[0])
+                        # match = ([block_replica], condition_id)
+                        unlinked_replicas, _ = self.unlink_block_replicas(replica, match[0])
                         if len(unlinked_replicas) != 0:
                             deleted_volume[site] += sum(br.size for br in unlinked_replicas)
                             deleted[replica].append((unlinked_replicas, match[1]))
@@ -376,6 +337,62 @@ class Detox(object):
 
         self.history.close_deletion_run(run_number)
 
+    def unlink_block_replicas(self, replica, block_replicas):
+        """
+        Unlink the dataset replica or parts of it from the owning containers.
+        Return the list of unlinked block replicas and reowned block replicas.
+        The second list is necessary for the caller to update its list of block
+        replicas to process, because owner change amounts to a rewrite of the
+        entire object under the current immutable blockreplica format.
+        """
+
+        if len(block_replicas) == len(replica.block_replicas):
+            for block_replica in block_replicas:
+                block_replica.unlink()
+
+            replica.unlink()
+
+            return block_replicas, []
+
+        else:
+            # Special operation - if we are deleting block replicas owned by group B, whose
+            # ownership level (see dataformats/group) is Block, but the block replicas belong
+            # to a dataset replica otherwise owned by group D, whose ownership level is Dataset,
+            # then we don't delete the block replicas but hand them over to D.
+
+            # establish a dataset-level owner
+            dr_owner = None
+            for block_replica in replica.block_replicas:
+                if block_replica.group.olevel is Dataset:
+                    # there is a dataset-level owner
+                    dr_owner = block_replica.group
+                    break
+
+            if dr_owner is None:
+                blocks_to_hand_over = []
+                blocks_to_unlink = list(block_replicas)
+            else:
+                blocks_to_hand_over = []
+                blocks_to_unlink = []
+                for block_replica in block_replicas:
+                    if block_replica.group.olevel is Dataset:
+                        blocks_to_unlink.append(block_replica)
+                    else:
+                        blocks_to_hand_over.append(block_replica)
+
+            if len(blocks_to_hand_over) != 0:
+                logger.debug('%d blocks to hand over to %s', len(blocks_to_hand_over), dr_owner.name)
+                # not ideal to make reassignments here, but this operation affects later iterations
+                reassigned_blocks = self.reassign_owner(replica, blocks_to_hand_over, dr_owner, policy.partition, is_test)
+
+            if len(blocks_to_unlink) != 0:
+                logger.debug('%d blocks to unlink', len(blocks_to_unlink))
+
+                for block_replica in blocks_to_unlink:
+                    block_replica.unlink()
+
+            return blocks_to_unlink, reassigned_blocks
+
     def reassign_owner(self, dataset_replica, block_replicas, new_owner, partition, is_test):
         """
         Add back the block replicas to dataset replica under the new owner.
@@ -399,6 +416,8 @@ class Detox(object):
         if not is_test:
             # are we relying on do_update = True in insert_many <- add_blockreplicas here?
             self.inventory_manager.store.add_blockreplicas(new_replicas)
+
+        return new_replicas
 
     def commit_deletions(self, run_number, policy, deletion_list, is_test, comment):
         """

--- a/lib/detox/policy.py
+++ b/lib/detox/policy.py
@@ -116,10 +116,6 @@ class PolicyLine(object):
                     # but all blocks matched - return dataset level
                     action = self.decision.action_cls.dataset_level(self)
                 else:
-                    # strip the block replicas from dataset replica
-                    for block_replica in block_replicas:
-                        replica.block_replicas.remove(block_replica)
-
                     action = self.decision.action(self, block_replicas)
             else:
                 action = self.decision.action(self)
@@ -351,6 +347,12 @@ class Policy(object):
             actions.append(action)
             if isinstance(action, DatasetAction):
                 break
+
+            else:
+                # strip the block replicas from dataset replica so the successive
+                # policy lines don't see them any more
+                for block_replica in action.block_replicas:
+                    replica.block_replicas.remove(block_replica)
 
         else:
             actions.append(self.default_decision.action(None))


### PR DESCRIPTION
1. Old cycle numbers were not removed from site_cache_usage table and was causing "cannot delete table sites_..." messages.
2. Bug in detox main logic. In the policy evaluation, we start with a full list of block replicas that belong to a dataset replica and keep taking block replicas out of the list as we encounter block-level policy lines (DeleteBlock, ProtectBlock, and KeepBlock). For DeleteBlock, in some rare cases, the blocks are actually not deleted but are reassigned to a new group (e.g. AnalysisOps). Because blockreplica is an immutable object, the reassigned versions are distinct objects from what is in the initial list. Then, later on when we check whether the block replica is in the list, we hit a "object not in list" exception. Fixed by replacing the old elements of the initial list with the reassigned versions.