### PR TITLE
Making popularity transfers go only from certain groups

### DIFF
--- a/lib/dealer/configuration.py
+++ b/lib/dealer/configuration.py
@@ -5,6 +5,7 @@ main = Configuration(
     max_dataset_size = 50., # Maximum dataset size to consider for copy in TB
     max_copy_per_site = 50., # Maximum volume to be copied per site in TB
     max_copy_total = 200.,
+    source_groups = ['AnalysisOps'],
     target_site_occupancy = 0.9,
     skip_existing = True
 )

--- a/lib/dealer/configuration.py
+++ b/lib/dealer/configuration.py
@@ -5,13 +5,13 @@ main = Configuration(
     max_dataset_size = 50., # Maximum dataset size to consider for copy in TB
     max_copy_per_site = 50., # Maximum volume to be copied per site in TB
     max_copy_total = 200.,
-    source_groups = ['AnalysisOps'],
     target_site_occupancy = 0.9,
     skip_existing = True
 )
 
 popularity = Configuration(
     request_to_replica_threshold = 1.75, # (weighted number of requests) / (number of replicas) above which replication happens
+    source_groups = ['AnalysisOps'],
     max_replicas = 10
 )
 

--- a/lib/dealer/plugins/popularity.py
+++ b/lib/dealer/plugins/popularity.py
@@ -40,7 +40,7 @@ class PopularityHandler(BaseHandler):
                 for br in dr.block_replicas:
                     if br.group.name in dealer_config.main.source_groups:
                         # found at least one block/dataset replica in source groups
-                        # therefore it is a valid dataset to replicate
+                        # therefore it is a legit dataset to replicate
                         dataset_in_source_groups = True
 
             if not dataset_in_source_groups:

--- a/lib/dealer/plugins/popularity.py
+++ b/lib/dealer/plugins/popularity.py
@@ -35,6 +35,17 @@ class PopularityHandler(BaseHandler):
             except KeyError:
                 continue
 
+            dataset_in_source_groups = False
+            for dr in dataset.replicas:
+                for br in dr.block_replicas:
+                    if br.group.name in dealer_config.main.source_groups:
+                        # found at least one block/dataset replica in source groups
+                        # therefore it is a valid dataset to replicate
+                        dataset_in_source_groups = True
+
+            if not dataset_in_source_groups:
+                continue
+
             if request_weight <= 0.:
                 continue
 

--- a/lib/dealer/plugins/popularity.py
+++ b/lib/dealer/plugins/popularity.py
@@ -38,7 +38,7 @@ class PopularityHandler(BaseHandler):
             dataset_in_source_groups = False
             for dr in dataset.replicas:
                 for br in dr.block_replicas:
-                    if br.group.name in dealer_config.main.source_groups:
+                    if br.group.name in dealer_config.popularity.source_groups:
                         # found at least one block/dataset replica in source groups
                         # therefore it is a legit dataset to replicate
                         dataset_in_source_groups = True

--- a/lib/dealer/plugins/popularity.py
+++ b/lib/dealer/plugins/popularity.py
@@ -38,7 +38,7 @@ class PopularityHandler(BaseHandler):
             dataset_in_source_groups = False
             for dr in dataset.replicas:
                 for br in dr.block_replicas:
-                    if br.group.name in dealer_config.popularity.source_groups:
+                    if br.group is not None and br.group.name in dealer_config.popularity.source_groups:
                         # found at least one block/dataset replica in source groups
                         # therefore it is a legit dataset to replicate
                         dataset_in_source_groups = True


### PR DESCRIPTION
We do not want to replicate datasets that were requested by a user when they are sitting e.g. only in the local group. Restrict popularity replication to specific source groups; default: AnalysisOps.