### PR TITLE
New variable for RelVal policy

### DIFF
--- a/lib/policy/producers/__init__.py
+++ b/lib/policy/producers/__init__.py
@@ -10,13 +10,15 @@ from globalqueue import GlobalQueueRequestHistory
 from mysqllock import MySQLReplicaLock
 from weblock import WebReplicaLock
 from protectedsite import ProtectedSiteTagger
+from datasetrelease import DatasetRelease
 
 __all__ = [
     'CRABAccessHistory',
     'GlobalQueueRequestHistory',
     'MySQLReplicaLock',
     'WebReplicaLock',
-    'ProtectedSiteTagger'
+    'ProtectedSiteTagger',
+    'DatasetRelease'
 ]
 
 # Dictionary of registered producers

--- a/lib/policy/producers/datasetrelease.py
+++ b/lib/policy/producers/datasetrelease.py
@@ -1,0 +1,48 @@
+import re
+import collections
+import logging
+
+from dynamo.utils.interface import RESTService
+
+LOG = logging.getLogger(__name__)
+
+class DatasetRelease(object):
+    """
+    Sets one attr:
+      latest_production_release
+    """
+
+    produces = ['latest_production_release']
+
+    def __init__(self, config):
+        self._dbs = RESTService(config.dbs.config)
+
+    def load(self, inventory):
+        latest_minor = collections.defaultdict(int)
+
+        results = self._dbs.make_request('acquisitioneras')
+        for result in results:
+            release = result['acquisition_era_name']
+            matches = re.match('CMSSW_([0-9]+)_([0-9]+)_([0-9]+)', release)
+            if not matches:
+                continue
+
+            cycle = int(matches.group(1))
+            major = int(matches.group(2))
+            minor = int(matches.group(3))
+
+            if minor > latest_minor[(cycle, major)]:
+                latest_minor[(cycle, major)] = minor
+
+        if LOG.getEffectiveLevel() == logging.DEBUG:
+            LOG.debug('Latest releases:')
+            for cm in sorted(latest_minor.keys()):
+                LOG.debug(cm + (latest_minor[cm],))
+
+        for dataset in inventory.datasets.itervalues():
+            release = dataset.software_version
+            if release is None:
+                continue
+
+            if release[2] == latest_minor[release[:2]]:
+                dataset.attr['latest_production_release'] = True

--- a/lib/policy/variables.py
+++ b/lib/policy/variables.py
@@ -281,6 +281,7 @@ replica_variables = {
     'dataset.usage_rank': DatasetAttr(Attr.NUMERIC_TYPE, dict_attr = 'global_usage_rank'),
     'dataset.demand_rank': DatasetAttr(Attr.NUMERIC_TYPE, dict_attr = 'global_demand_rank'),
     'dataset.release': DatasetRelease(),
+    'dataset.is_latest_production_release': DatasetAttr(Attr.BOOL_TYPE, dict_attr = 'latest_production_release', dict_default = False),
     'dataset.on_protected_site': DatasetAttr(Attr.BOOL_TYPE, dict_attr = 'on_protected_site', dict_default = False),
     'replica.is_last_transfer_source': ReplicaIsLastSource(),
     'replica.size': ReplicaSize(),

--- a/sbin/dynamo-scheduled
+++ b/sbin/dynamo-scheduled
@@ -256,7 +256,7 @@ def loop_sequence(sequence_name, sequence, user_id, config):
         if action[0] == EXECUTE:
             action_texts.append(action[1])
         elif action[0] == WAIT:
-            action_texts.append('WAIT(%d)' % action[2])
+            action_texts.append('WAIT(%d)' % action[1])
         elif action[0] == TERMINATE:
             action_texts.append('TERMINATE')
 

--- a/web/cgi-bin/dynamo/detox/html/locks.html
+++ b/web/cgi-bin/dynamo/detox/html/locks.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Detox locks</title>
+    <style>
+      table, th, td {
+      padding: 3px;
+      border: 1px solid black;
+      }
+    </style>
+  </head>
+  <body>
+    <table style='width = 50%' >
+      <tr><th> NAME </th><th> EMAIL </th><th> ITEM </th><th> SITE </th><th> LOCK DATE </th><th> UNLOCK DATE </th><th> EXPIRATION DATE </th><th> COMMENT </th></tr>
+      ${TABLE_CONT}
+    </table>
+  </body>
+</html>

--- a/web/cgi-bin/dynamo/detox/locks.php
+++ b/web/cgi-bin/dynamo/detox/locks.php
@@ -1,0 +1,80 @@
+<?php
+
+include_once(__DIR__ . '/../common/db_conf.php');
+
+$db = new mysqli($db_conf['host'], $db_conf['user'], $db_conf['password'], 'dynamoregister');
+
+$join_clause = array();
+$where_clause = array();
+
+if (isset($_REQUEST['user_name'])) {
+  $user_name = $_REQUEST['user_name'];
+  $join_clause['users'] = 'INNER JOIN `users` ON `users`.`id` = `detox_locks`.`user_id`';
+  $where_clause[] = sprintf('`users`.`name` = "%s"', $user_name);
+}
+
+$locked = "y";
+if (isset($_REQUEST['locked']))
+  $locked = $_REQUEST['locked'];
+
+if ($locked == "y")
+  $where_clause[] = '`unlock_date` IS NULL';
+else if ($locked == "n")
+  $where_clause[] = '`unlock_date` IS NOT NULL';
+else {
+  // invalid value
+}
+
+if (isset($_REQUEST['locked_since']))
+  $where_clause[] = sprintf('`lock_date` >= "%s"', $_REQUEST['locked_since']);
+
+if (isset($_REQUEST['locked_before']))
+  $where_clause[] = sprintf('`lock_date` <= "%s"', $_REQUEST['locked_before']);
+
+if (isset($_REQUEST['unlocked_since']))
+  $where_clause[] = sprintf('`unlock_date` >=  "%s"', $_REQUEST['unlocked_since']);
+
+if (isset($_REQUEST['unlocked_before']))
+  $where_clause[] = sprintf('`unlock_date` <=  "%s"', $_REQUEST['unlocked_before']);
+
+if (isset($_REQUEST['site']))
+  $where_clause[] = sprintf('`sites` = "%s"', $_REQUEST['site']);
+
+if (isset($_REQUEST['expires_after']))
+  $where_clause[] = sprintf('`expiration_date` > "%s"', $_REQUEST['expires_after']);
+
+if (isset($_REQUEST['expires_before']))
+  $where_clause[] = sprintf('`expiration_date` <  "%s"', $_REQUEST['expires_before']);
+
+if (isset($_REQUEST['item']))
+  $where_clause[] = sprintf('`item` LIKE "%s" ', str_replace("*", "%", $_REQUEST['item']));
+
+$final_join_clause = implode(' ', $join_clause);
+$final_where_clause = ' WHERE ' . implode(" AND ", $where_clause);
+
+$query = 'SELECT `item`, `sites`, `lock_date`, `unlock_date`, `expiration_date`, `comment`, `name`, `email`';
+$query .= ' FROM `detox_locks` ' . $final_join_clause;
+$query .= $final_where_clause;
+
+$html = file_get_contents(__DIR__ . '/html/locks.html');
+
+$table_cont = '';
+
+$stmt = $db->prepare($query);
+$stmt->bind_result($item, $sites, $lockdate, $unlockdate, $expiration_date, $comment, $name, $email);
+$stmt->execute();
+while($stmt->fetch()) {
+  if ($unlockdate === NULL)
+    $unlockdate_td = '<td style="text-align:center;">---</td>';
+  else
+    $unlockdate_td = '<td>' . $unlockdate . '</td>';
+
+  $table_cont .= '<tr><td>' . $name . '</td><td>' . $email . '</td><td>' . $item . '</td><td>' . $sites . '</td><td>' . $lockdate . '</td>' . $unlockdate_td . '<td>' . $expiration_date . '</td><td>' . $comment . '</td> </tr>';
+}
+$stmt->close();
+
+$html = str_replace('${TABLE_CONT}', "$cycle", $table_cont);
+
+echo $html;
+
+?>

--- a/web/install.sh
+++ b/web/install.sh
@@ -79,6 +79,7 @@ rm $BINTARGET/dynamo/common/db_conf.php.template
 [ -e /tmp/db_conf.php.$$ ] && mv /tmp/db_conf.php.$$ $BINTARGET/dynamo/common/db_conf.php
 
 [ -L $HTMLTARGET/dynamo/detox.php ] || ln -sf $BINTARGET/dynamo/detox/main.php $HTMLTARGET/dynamo/detox.php
+[ -L $HTMLTARGET/dynamo/detoxlocks.php ] || ln -sf $BINTARGET/dynamo/detox/locks.php $HTMLTARGET/dynamo/detoxlocks.php
 [ -L $HTMLTARGET/dynamo/inventory.php ] || ln -sf $BINTARGET/dynamo/inventory/main.php $HTMLTARGET/dynamo/inventory.php
 [ -L $HTMLTARGET/registry/detoxlock ] || ln -sf $BINTARGET/registry/detoxlock.php $HTMLTARGET/registry/detoxlock
 [ -L $HTMLTARGET/registry/activitylock ] || ln -sf $BINTARGET/registry/activitylock.php $HTMLTARGET/registry/activitylock


### PR DESCRIPTION
Added a new policy producer for attribute latest_production_release. The value is True for datasets with the latest minor release version of each major release.
Example: True for datasets with release CMSSW_5_3_23, False for CMSSW_9_2_14.