### PR TITLE
Installation

### DIFF
--- a/db/dynamo.sql
+++ b/db/dynamo.sql
@@ -37,7 +37,7 @@ CREATE TABLE `blocks` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `datasets` (`dataset_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `dataset_accesses`;
@@ -95,7 +95,7 @@ CREATE TABLE `datasets` (
   `is_open` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `files`;
@@ -109,7 +109,7 @@ CREATE TABLE `files` (
   UNIQUE KEY `name` (`name`),
   KEY `datasets` (`dataset_id`),
   KEY `blocks` (`block_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `groups`;
@@ -119,7 +119,7 @@ CREATE TABLE `groups` (
   `olevel` enum('Dataset','Block') CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL DEFAULT 'Block',
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `partitions`;
@@ -128,7 +128,7 @@ CREATE TABLE `partitions` (
   `name` varchar(16) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `quotas`;
@@ -153,7 +153,7 @@ CREATE TABLE `sites` (
   `status` enum('ready','waitroom','morgue','unknown') CHARACTER SET latin1 COLLATE latin1_general_ci NOT NULL DEFAULT 'ready',
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `software_versions`;
@@ -165,7 +165,7 @@ CREATE TABLE `software_versions` (
   `suffix` varchar(64) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `release` (`cycle`,`major`,`minor`,`suffix`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `system`;

--- a/db/dynamohistory.sql
+++ b/db/dynamohistory.sql
@@ -37,7 +37,7 @@ CREATE TABLE `datasets` (
   `name` varchar(512) CHARACTER SET latin1 COLLATE latin1_general_cs NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `deleted_replicas`;
@@ -73,7 +73,7 @@ CREATE TABLE `partitions` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(128) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `policy_conditions`;
@@ -82,7 +82,7 @@ CREATE TABLE `policy_conditions` (
   `text` varchar(512) COLLATE latin1_general_cs NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `text` (`text`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 
 
 DROP TABLE IF EXISTS `runs`;
@@ -97,7 +97,7 @@ CREATE TABLE `runs` (
   PRIMARY KEY (`id`),
   KEY `operations` (`operation`),
   KEY `partitions` (`partition_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
 DROP TABLE IF EXISTS `sites`;
@@ -106,6 +106,6 @@ CREATE TABLE `sites` (
   `name` varchar(32) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 

--- a/db/dynamohistory_cache.sql
+++ b/db/dynamohistory_cache.sql
@@ -1,15 +1,6 @@
 
 
 
-DROP TABLE IF EXISTS `replicas_snapshot_usage`;
-CREATE TABLE `replicas_snapshot_usage` (
-  `run_id` int(11) unsigned NOT NULL,
-  `timestamp` datetime NOT NULL,
-  KEY `runs` (`run_id`),
-  KEY `timestamps` (`timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
-
-
 DROP TABLE IF EXISTS `replicas`;
 CREATE TABLE `replicas` (
   `site_id` int(10) unsigned NOT NULL,
@@ -21,8 +12,8 @@ CREATE TABLE `replicas` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 
-DROP TABLE IF EXISTS `sites_snapshot_usage`;
-CREATE TABLE `sites_snapshot_usage` (
+DROP TABLE IF EXISTS `replicas_snapshot_usage`;
+CREATE TABLE `replicas_snapshot_usage` (
   `run_id` int(11) unsigned NOT NULL,
   `timestamp` datetime NOT NULL,
   KEY `runs` (`run_id`),
@@ -36,6 +27,15 @@ CREATE TABLE `sites` (
   `status` enum('ready','waitroom','morgue','unknown') NOT NULL,
   `quota` int(10) NOT NULL,
   PRIMARY KEY (`site_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+
+DROP TABLE IF EXISTS `sites_snapshot_usage`;
+CREATE TABLE `sites_snapshot_usage` (
+  `run_id` int(11) unsigned NOT NULL,
+  `timestamp` datetime NOT NULL,
+  KEY `runs` (`run_id`),
+  KEY `timestamps` (`timestamp`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 
 

--- a/db/grants.sh
+++ b/db/grants.sh
@@ -79,7 +79,7 @@ new_user () {
   HOST=$2
   PASSWD=$3
 
-  NEXIST=$(echo 'SELECT COUNT(*) FROM `mysql`.`user` WHERE `User` = "dynamowrite" AND `Host` = "'$HOST'";' | $ROOTSQL --skip-column-names)
+  NEXIST=$(echo 'SELECT COUNT(*) FROM `mysql`.`user` WHERE `User` = "'$USER'" AND `Host` = "'$HOST'";' | $ROOTSQL --skip-column-names)
   if [ $NEXIST -gt 0 ]
   then
     echo
@@ -92,15 +92,15 @@ new_user () {
 
 
 ## Ask for user names
-echo "User name for the Dynamo server (config.sh:$SERVER_DB_WRITE_USER):"
+echo 'User name for the Dynamo server (config.sh:$SERVER_DB_WRITE_USER):'
 read SERVER_USER
 echo "Password for $SERVER_USER:"
 read SERVER_USER_PASSWD
-echo "User name for elevated-privilege executables (write-allowed to some tables; not in config.sh):"
+echo 'User name for elevated-privilege executables (write-allowed to some tables; not in config.sh):'
 read PRIV_USER
 echo "Password for $PRIV_USER:"
 read PRIV_USER_PASSWD
-echo "User name for normal executables (config.sh:$SERVER_DB_READ_USER):"
+echo 'User name for normal executables (config.sh:$SERVER_DB_READ_USER):'
 read NORMAL_USER
 echo "Password for $NORMAL_USER:"
 read NORMAL_USER_PASSWD

--- a/db/install.sh
+++ b/db/install.sh
@@ -68,7 +68,7 @@ do
   fi
 done
 
-echo "DROP DATABASE dynamo_tmp;" | mysql $MYSQLOPT
+echo "DROP DATABASE IF EXISTS dynamo_tmp;" | mysql $MYSQLOPT
 echo "CREATE DATABASE dynamo_tmp;" | mysql $MYSQLOPT
 
 cd ..

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,21 @@ mkdir -p $SPOOL_PATH
 chown $USER:$(id -gn $USER) $SPOOL_PATH
 chmod 777 $SPOOL_PATH
 
+if [ $(ls -ldZ $SPOOL_PATH | awk '{print $4}' | cut -d: -f3) != "httpd_sys_rw_content_t" ]
+then
+  ### Set SELinux context to allow the web server to write to SPOOL
+  
+  echo "Updating SELinux contexts.."
+  
+  semanage fcontext -a -t httpd_sys_rw_content_t $SPOOL_PATH
+  restorecon $SPOOL_PATH
+  setsebool -P httpd_can_network_connect on
+  setsebool -P httpd_can_network_connect_db on
+fi
+
 ### Install python libraries ###
+
+echo "Installing.."
 
 cp -r $SOURCE/lib/* $INSTALL_PATH/python/site-packages/dynamo/
 python -m compileall $INSTALL_PATH/python/site-packages/dynamo > /dev/null

--- a/sbin/dynamo-user-auth
+++ b/sbin/dynamo-user-auth
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description = 'Dynamo registry user tools')
+parser.add_argument('--user', '-u', metavar = 'USER', dest = 'user', help = 'User name.')
+parser.add_argument('--dn', '-n', metavar = 'DN', dest = 'dn', help = 'Add or update the user and link to this DN.')
+parser.add_argument('--email', '-m', metavar = 'ADDR', dest = 'email', help = 'Set user email address.')
+parser.add_argument('--service', '-s', metavar = 'NAME', dest = 'service', help = 'Service name to authorize the user in.')
+parser.add_argument('--log-level', '-l', metavar = 'LEVEL', dest = 'log_level', default = 'INFO', help = 'Logging level.')
+parser.add_argument('--revoke', '-R', action = 'store_true', dest = 'revoke', help = 'Revoke the authorization.')
+parser.add_argument('--list', '-L', action = 'store_true', dest = 'list', help = 'List authorizations')
+
+args = parser.parse_args()
+sys.argv = []
+
+## Process option combinations
+if not args.list and (not args.user or not args.service):
+    print '--user and --service are required if not --list.'
+    sys.exit(2)
+
+try:
+    debug = (os.environ['DYNAMO_SERVER_DEBUG'] == '1')
+except:
+    debug = False
+
+if not debug:
+    if os.geteuid() != 0:
+        sys.stderr.write('Root privilege required\n')
+        sys.exit(1)
+
+## Read server config (should be readable only to root)
+
+from dynamo.dataformat import Configuration
+
+try:
+    config_path = os.environ['DYNAMO_SERVER_CONFIG']
+except KeyError:
+    config_path = '/etc/dynamo/server_config.json'
+
+server_config = Configuration(config_path)
+
+## Create the registry
+
+from dynamo.core.registry import DynamoRegistry
+
+registry = DynamoRegistry(server_config.registry)
+
+if args.user:
+    uid_arr = registry.backend.query('SELECT `id` FROM `users` WHERE `name` = %s', args.user)
+    
+    if len(uid_arr) == 0:
+        if args.revoke:
+            print 'User does not exist'
+            sys.exit(0)
+    
+        if not args.dn:
+            print 'New user; DN is required'
+            sys.exit(1)
+    
+        user_id = registry.backend.query('INSERT INTO `users` (`name`, `domain_id`, `email`, `dn`) VALUES (%s, 0, %s, %s)', args.user, args.email, args.dn)
+    else:
+        user_id = uid_arr[0]
+else:
+    user_id = 0
+
+if args.service:
+    sid_arr = registry.backend.query('SELECT `id` FROM `services` WHERE `name` = %s', args.service)
+    
+    if len(sid_arr) == 0:
+        print 'Create new service "%s"? [y/N]' % args.service
+        while True:
+            response = sys.stdin.readline().strip()
+            if response == 'y':
+                break
+            elif response == 'N':
+                print 'Exiting.'
+                sys.exit(0)
+            else:
+                print 'Please answer in y/N.'
+    
+        service_id = registry.backend.query('INSERT INTO `services` (`name`) VALUES (%s)', args.service)
+    else:
+        service_id = sid_arr[0]
+else:
+    service_id = 0
+
+if args.list:
+    sql = 'SELECT u.`name`, s.`name` FROM `authorized_users` AS a'
+    sql += ' INNER JOIN `users` AS u ON u.`id` = a.`user_id`'
+    sql += ' INNER JOIN `services` AS s ON s.`id` = a.`service_id`'
+    constraints = []
+    if user_id != 0:
+        constraints.append('u.`id` = %d' % user_id)
+    if service_id != 0:
+        constraints.append('s.`id` = %d' % service_id)
+
+    if len(constraints):
+        sql += ' WHERE ' + ' AND '.join(constraints)
+
+    print 'USER   SERVICE'
+    for user, service in registry.backend.query(sql):
+        print user, service
+        
+elif args.revoke:
+    registry.backend.query('DELETE FROM `authorized_users` WHERE `user_id` = %s AND `service_id` = %s', user_id, service_id)
+else:
+    registry.backend.query('INSERT IGNORE INTO `authorized_users` VALUES (%s, %s)', user_id, service_id)

--- a/web/cgi-bin/registry/interface.php
+++ b/web/cgi-bin/registry/interface.php
@@ -3,6 +3,11 @@
 include_once(__DIR__ . '/../dynamo/common/db_conf.php');
 include_once(__DIR__ . '/common.php');
 
+if (isset($_REQUEST['greet'])) {
+  echo "Hello";
+  exit(0);
+}
+
 $username = $_SERVER['SSL_CLIENT_S_DN_CN'];
 
 $filedata = '';

--- a/web/install.sh
+++ b/web/install.sh
@@ -35,6 +35,7 @@ TEST=$(sed -n 's/.*max_execution_time[^0-9]*\([0-9]*\)/\1/p' /etc/php.ini)
 if ! [ $TEST ] || [ $TEST -lt 600 ]
 then
   echo "!!! PHP max_execution_time is less than the recommended value of 10 minutes."
+  echo
 fi
 
 # Also should check memory_limit
@@ -91,5 +92,21 @@ rm $BINTARGET/dynamo/common/db_conf.php.template
 
 mv /tmp/dealermon.$$ $HTMLTARGET/dynamo/dealermon
 chmod 777 $HTMLTARGET/dynamo/dealermon
+
+### Verify .htaccess override
+MESSAGE=$(curl -s 'http://localhost/registry/application?greet')
+if [ "$MESSAGE" != "Hello" ]
+then
+  echo "Web server installation failed. This is most likely due to the base http server configuration."
+  echo "Please check if the following line is under the root directory configuration directive:"
+  echo "   AllowOverride FileInfo Options AuthConfig"
+  exit 1
+fi
+
+echo "Please confirm that the web server is capable of serving requests using X509 certificate proxies."
+echo "In particular, for apache, the environment variable"
+echo "export OPENSSL_ALLOW_PROXY_CERTS=1"
+echo "must be set in the httpd execution environment."
+echo "The line above should be placed in /etc/init.d/httpd (SL6) or /etc/sysconfig/httpd (CentOS 7, without export)."
 
 exit 0


### PR DESCRIPTION
Added SELinux context setting in the install script.
Tried this version with a fresh install on t3serv016, and (although I had some general problem with apache https) the jobs could be submitted without any audit2allow commands. I guess that's a success.