### PR TITLE
inventory update bugfix

### DIFF
--- a/config/siteinfo_config.json
+++ b/config/siteinfo_config.json
@@ -4,12 +4,12 @@
     "module": "MySQLHistory",
     "config": {
       "db_params": {
-        "config_file": "/etc/my.cnf.d/dynamo.cnf",
+        "config_file": "/etc/my.cnf.d/dynamo-read.cnf",
         "config_group": "mysql",
         "db": "dynamohistory"
       },
       "cache_db_params": {
-        "config_file": "/etc/my.cnf.d/dynamo.cnf",
+        "config_file": "/etc/my.cnf.d/dynamo-read.cnf",
         "config_group": "mysql",
         "db": "dynamohistory_cache"
       },

--- a/exec/updater_cms
+++ b/exec/updater_cms
@@ -532,17 +532,13 @@ if check_replicas:
     
         # blockreplica.unlink_from() raises a KeyError or ObjectError if
         # any of the group, site, dataset, ... is not found
+        # containing dataset replica will be deleted within blockreplica.unlink()
+        # if it becomes empty
         try:
             inventory.delete(replica)
         except (KeyError, ObjectError):
             LOG.debug('Replica not found.')
             pass
-    
-        # 6.7. Delete the dataset replica if it is empty
-    
-        if len(dataset_replica.block_replicas) == 0:
-            LOG.info('Deleting replica %s:%s', site.name, dataset.name)
-            inventory.delete(dataset_replica)
 
 # 7. Save the execution state
 

--- a/exec/updater_cms
+++ b/exec/updater_cms
@@ -530,7 +530,7 @@ if check_replicas:
     
         # 6.6. Delete the block replica
     
-        # blockreplica.delete_from() raises a KeyError or ObjectError if
+        # blockreplica.unlink_from() raises a KeyError or ObjectError if
         # any of the group, site, dataset, ... is not found
         try:
             inventory.delete(replica)

--- a/lib/core/inventory.py
+++ b/lib/core/inventory.py
@@ -37,7 +37,7 @@ class ObjectRepository(object):
 
     def delete(self, obj):
         try:
-            return obj.delete_from(self)
+            return obj.unlink_from(self)
         except (KeyError, ObjectError) as e:
             # When delete is attempted on a nonexistent object or something linked to a nonexistent object
             # As this is less alarming, error message is suppressed to debug level.
@@ -302,7 +302,7 @@ class DynamoInventory(ObjectRepository):
 
         if write:
             try:
-                deleted_object.write_into(self._store, delete = True)
+                deleted_object.delete_from(self._store)
             except:
                 LOG.error('Exception writing deletion of %s to inventory store', str(obj))
                 raise

--- a/lib/core/persistency.py
+++ b/lib/core/persistency.py
@@ -1,7 +1,11 @@
 import time
 
 class InventoryStore(object):
-    """Interface definition for local inventory data store."""
+    """
+    Interface definition for local inventory data store.
+    Implementation of save_* functions must mirror what is in embed_into() of the object.
+    Implementation of delete_* functions must mirror what is in unlink_from() of the object.
+    """
 
     def __init__(self, config):
         pass
@@ -83,37 +87,77 @@ class InventoryStore(object):
         raise NotImplementedError('save_file')
     
     def save_partition(self, partition):
+        """
+        If a new partition, create site partitions with default parameters.
+        """
         raise NotImplementedError('save_file')
 
     def save_site(self, site):
+        """
+        If a new site, create site partitions with default parameters.
+        """
         raise NotImplementedError('save_site')
 
     def save_sitepartition(self, site_partition):
+        """
+        Should only do updates.
+        """
         raise NotImplementedError('save_sitepartition')
 
     def delete_block(self, block):
+        """
+        1. Delete all replicas of the block.
+        2. Delete all files belonging to the block.
+        3. Delete the block.
+        """
         raise NotImplementedError('delete_block')
 
     def delete_blockreplica(self, block_replica):
+        """
+        1. Delete the block replica.
+        2. Delete the owning dataset replica if it becomes empty.
+        """
         raise NotImplementedError('delete_blockreplica')
 
     def delete_dataset(self, dataset):
+        """
+        1. Delete all replicas of the dataset.
+        2. Delete all blocks belonging to the block.
+        3. Delete the dataset.
+        """
         raise NotImplementedError('delete_dataset')
 
     def delete_datasetreplica(self, dataset_replica):
+        """
+        1. Delete all block replicas.
+        2. Delete the dataset replica.
+        """
         raise NotImplementedError('delete_datasetreplica')
 
     def delete_group(self, group):
+        """
+        1. Set owner of all the block replicas owned by the group to None.
+        2. Delete the group.
+        """
         raise NotImplementedError('delete_group')
 
     def delete_file(self, lfile):
+        """
+        1. Delete the file.
+        """
         raise NotImplementedError('delete_file')
     
     def delete_partition(self, partition):
+        """
+        1. Delete all site partitions.
+        2. Delete the partition.
+        """
         raise NotImplementedError('delete_file')
 
     def delete_site(self, site):
+        """
+        1. Delete all dataset replicas at the site.
+        2. Delete the site partitions.
+        3. Delete the site.
+        """
         raise NotImplementedError('delete_site')
-
-    def delete_sitepartition(self, site_partition):
-        raise NotImplementedError('delete_sitepartition')

--- a/lib/dataformat/block.py
+++ b/lib/dataformat/block.py
@@ -152,7 +152,7 @@ class Block(object):
         else:
             return block
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         try:
             dataset = inventory.datasets[self._dataset_name()]
             block = dataset.find_block(self._name, must_find = True)
@@ -173,11 +173,11 @@ class Block(object):
         self._dataset.size -= self.size
         self._dataset.num_files -= self.num_files
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_block(self)
-        else:
-            store.save_block(self)
+    def write_into(self, store):
+        store.save_block(self)
+
+    def delete_from(self, store):
+        store.delete_block(self)
 
     def real_name(self):
         """

--- a/lib/dataformat/blockreplica.py
+++ b/lib/dataformat/blockreplica.py
@@ -112,7 +112,7 @@ class BlockReplica(object):
         else:
             return replica
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         try:
             dataset = inventory.datasets[self._dataset_name()]
             block = dataset.find_block(self._block_name(), must_find = True)
@@ -153,11 +153,11 @@ class BlockReplica(object):
 
         self._block.replicas.remove(self)
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_blockreplica(self)
-        else:
-            store.save_blockreplica(self)
+    def write_into(self, store):
+        store.save_blockreplica(self)
+
+    def delete_from(self, store):
+        store.delete_blockreplica(self)
 
     def _block_full_name(self):
         if type(self._block) is str:

--- a/lib/dataformat/dataset.py
+++ b/lib/dataformat/dataset.py
@@ -141,7 +141,7 @@ class Dataset(object):
         else:
             return dataset
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         try:
             dataset = inventory.datasets.pop(self._name)
         except KeyError:
@@ -155,11 +155,11 @@ class Dataset(object):
 
         return dataset
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_dataset(self)
-        else:
-            store.save_dataset(self)
+    def write_into(self, store):
+        store.save_dataset(self)
+
+    def delete_from(self, store):
+        store.delete_dataset(self)
 
     def find_block(self, block_name, must_find = False):
         try:

--- a/lib/dataformat/datasetreplica.py
+++ b/lib/dataformat/datasetreplica.py
@@ -75,7 +75,7 @@ class DatasetReplica(object):
         else:
             return replica
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         try:
             dataset = inventory.datasets[self._dataset_name()]
             site = inventory.sites[self._site_name()]
@@ -103,11 +103,11 @@ class DatasetReplica(object):
 
         self._dataset.replicas.remove(self)
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_datasetreplica(self)
-        else:
-            store.save_datasetreplica(self)
+    def write_into(self, store):
+        store.save_datasetreplica(self)
+
+    def delete_from(self, store):
+        store.delete_datasetreplica(self)
 
     def is_last_copy(self):
         return len(self._dataset.replicas) == 1 and self._dataset.replicas[0] == self

--- a/lib/dataformat/group.py
+++ b/lib/dataformat/group.py
@@ -81,13 +81,13 @@ class Group(object):
         else:
             return group
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         if self._name is None:
             raise ObjectError('Deletion of null group not allowed')
 
         # Pop the group from the main list. All block replicas owned by the group
         # will be disowned.
-        # Update to block replicas will be propagated at by calling Group.delete_from
+        # Update to block replicas will be propagated at by calling Group.unlink_from
         # at each inventory instance.
         # Database update must be taken care of by persistency store delete_group().
         try:
@@ -103,13 +103,16 @@ class Group(object):
 
         return group
 
-    def write_into(self, store, delete = False):
+    def write_into(self, store):
         if self._name is None:
             return
 
-        if delete:
-            store.delete_group(self)
-        else:
-            store.save_group(self)
+        store.save_group(self)
+
+    def delete_from(self, store):
+        if self._name is None:
+            raise ObjectError('Deletion of null group not allowed')
+
+        store.delete_group(self)
 
 Group.null_group = Group(None)

--- a/lib/dataformat/lfile.py
+++ b/lib/dataformat/lfile.py
@@ -113,7 +113,7 @@ class File(object):
         else:
             return lfile
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         if self._block_name() is None:
             return None
 
@@ -136,11 +136,11 @@ class File(object):
         self._block.size -= self.size
         self._block.num_files -= 1
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_file(self)
-        else:
-            store.save_file(self)
+    def write_into(self, store):
+        store.save_file(self)
+
+    def delete_from(self, store):
+        store.delete_file(self)
 
     def fid(self):
         return (self._directory_id, self._basename)

--- a/lib/dataformat/partition.py
+++ b/lib/dataformat/partition.py
@@ -95,7 +95,7 @@ class Partition(object):
         else:
             return partition
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         try:
             partition = inventory.partitions.pop(self._name)
         except KeyError:
@@ -106,11 +106,12 @@ class Partition(object):
 
         return partition
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_partition(self)
-        else:
-            store.save_partition(self)
+    def write_into(self, store):
+        store.save_partition(self)
+        # if a new partition, store must create SitePartition entries with default values
+
+    def delete_from(self, store):
+        store.delete_partition(self)
 
     def contains(self, replica):
         if self._subpartitions is None:

--- a/lib/dataformat/sitepartition.py
+++ b/lib/dataformat/sitepartition.py
@@ -1,6 +1,6 @@
 import sys
 
-from exceptions import IntegrityError
+from exceptions import ObjectError, IntegrityError
 
 class SitePartition(object):
     """State of a partition at a site."""
@@ -83,11 +83,7 @@ class SitePartition(object):
         try:
             site_partition = site.partitions[partition]
         except KeyError:
-            site_partition = SitePartition(site, partition)
-            site_partition.copy(self)
-            site.partitions[partition] = site_partition
-            updated = True
-
+            IntegrityError('SitePartition %s/%s must exist but does not.', site.name, partition.name)
         else:            
             if check and (site_partition is self or site_partition == self):
                 # identical object -> return False if check is requested
@@ -101,14 +97,14 @@ class SitePartition(object):
         else:
             return site_partition
 
-    def delete_from(self, inventory):
+    def unlink_from(self, inventory):
         raise ObjectError('Deletion of a single SitePartition is not allowed.')
 
-    def write_into(self, store, delete = False):
-        if delete:
-            store.delete_sitepartition(self)
-        else:
-            store.save_sitepartition(self)
+    def write_into(self, store):
+        store.save_sitepartition(self)
+
+    def delete_from(self, store):
+        raise ObjectError('Deletion of a single SitePartition is not allowed.')
 
     def set_quota(self, quota):
         if self._partition.subpartitions is not None:

--- a/lib/detox/main.py
+++ b/lib/detox/main.py
@@ -295,7 +295,7 @@ class Detox(object):
 
                             # unlinked_replicas on the other hand contains all block replicas that should be kicked out
                             for block_replica in unlinked_replicas:
-                                block_replica.delete_from(repository)
+                                block_replica.unlink_from(repository)
 
                             block_replicas -= set(unlinked_replicas)
 
@@ -326,7 +326,7 @@ class Detox(object):
                             get_list(deleted, replica, condition_id).update(set(unlinked_replicas) - set(reowned_replicas))
 
                             for block_replica in unlinked_replicas:
-                                block_replica.delete_from(repository)
+                                block_replica.unlink_from(repository)
 
                         if len(replica.block_replicas) == 0:
                             # if all blocks were deleted, take the replica off all_replicas for later iterations
@@ -346,7 +346,7 @@ class Detox(object):
                             get_list(keep_candidates, replica, condition_id).update(block_replicas)
 
             for replica in empty_replicas:
-                replica.delete_from(repository)
+                replica.unlink_from(repository)
 
             all_replicas -= empty_replicas
             all_replicas -= ignored_replicas
@@ -427,7 +427,7 @@ class Detox(object):
 
                             get_list(deleted, replica, condition_id).update(to_delete)
                             for block_replica in unlinked_replicas:
-                                block_replica.delete_from(repository)
+                                block_replica.unlink_from(repository)
 
                         if len(reowned_replicas) != 0:
                             if replica in reowned:
@@ -436,7 +436,7 @@ class Detox(object):
                                 reowned[replica] = list(reowned_replicas)
 
                     if len(replica.block_replicas) == 0:
-                        replica.delete_from(repository)
+                        replica.unlink_from(repository)
                         all_replicas.remove(replica)
 
                     site_partition = site.partitions[partition]

--- a/lib/source/impl/phedexreplicainfo.py
+++ b/lib/source/impl/phedexreplicainfo.py
@@ -114,7 +114,7 @@ class PhEDExReplicaInfoSource(ReplicaInfoSource):
     def get_updated_replicas(self, updated_since): #override
         LOG.info('get_updated_replicas(%d)  Fetching the list of replicas from PhEDEx', updated_since)
 
-        result = self._phedex.make_request('blockreplicas', ['show_dataset=y', 'update_since=%d' % updated_since])
+        result = self._phedex.make_request('blockreplicas', ['show_dataset=y', 'create_since=0', 'update_since=%d' % updated_since])
         
         return PhEDExReplicaInfoSource.make_block_replicas(result, PhEDExReplicaInfoSource.maker_blockreplicas)
 

--- a/lib/utils/interface/mysql.py
+++ b/lib/utils/interface/mysql.py
@@ -49,6 +49,8 @@ class MySQL(object):
         # default 1M characters
         self.max_query_len = config.get('max_query_len', 1000000)
 
+        self.last_insert_id = 0
+
     def db_name(self):
         return self._connection_parameters['db']
 
@@ -80,6 +82,8 @@ class MySQL(object):
             self._connection = MySQLdb.connect(**self._connection_parameters)
 
         cursor = self._connection.cursor()
+
+        self.last_insert_id = 0
 
         try:
             if LOG.getEffectiveLevel() == logging.DEBUG:
@@ -126,6 +130,7 @@ class MySQL(object):
             if cursor.description is None:
                 if cursor.lastrowid != 0:
                     # insert query
+                    self.last_insert_id = cursor.lastrowid
                     return cursor.lastrowid
                 else:
                     # update query
@@ -157,6 +162,8 @@ class MySQL(object):
             self._connection = MySQLdb.connect(**self._connection_parameters)
 
         cursor = self._connection.cursor(MySQLdb.cursors.SSCursor)
+
+        self.last_insert_id = 0
 
         try:
             if LOG.getEffectiveLevel() == logging.DEBUG:

--- a/web/cgi-bin/dynamo/inventory/main.php
+++ b/web/cgi-bin/dynamo/inventory/main.php
@@ -80,13 +80,13 @@ else if (isset($_REQUEST['getData']) && $_REQUEST['getData']) {
 
   $data = array('dataType' => $data_type, 'content' => array());
 
-  $stmt = $store_db->prepare('SELECT `last_update` FROM `system`');
+  $stmt = $store_db->prepare('SELECT UNIX_TIMESTAMP(`last_update`) FROM `system`');
   $stmt->bind_result($last_update);
   $stmt->execute();
   $stmt->fetch();
   $stmt->close();
 
-  $data['lastUpdate'] = $last_update;
+  $data['lastUpdate'] = strftime('%Y-%m-%d %H:%M:%S UTC', $last_update);
 
   $content = &$data['content'];
 

--- a/web/cgi-bin/registry/activitylock.class.php
+++ b/web/cgi-bin/registry/activitylock.class.php
@@ -134,7 +134,7 @@ class ActivityLock {
   
   private function get_lock($app, &$first_uid, &$first_sid)
   {
-    $query = 'SELECT u.`id`, s.`id`, u.`name`, s.`name`, l.`timestamp`, l.`note` FROM `activity_lock` AS l';
+    $query = 'SELECT u.`id`, s.`id`, u.`name`, s.`name`, UNIX_TIMESTAMP(l.`timestamp`), l.`note` FROM `activity_lock` AS l';
     $query .= ' INNER JOIN `users` AS u ON u.`id` = l.`user_id`';
     $query .= ' INNER JOIN `services` AS s ON s.`id` = l.`service_id`';
     $query .= ' WHERE l.`application` = ?';
@@ -161,7 +161,7 @@ class ActivityLock {
     $data['user'] = $uname;
     if ($sname != 'user')
       $data['service'] = $sname;
-    $data['lock_time'] = $timestamp;
+    $data['lock_time'] = strftime('%Y-%m-%d %H:%M:%S UTC', $timestamp);
     if ($note !== NULL)
       $data['note'] = $note;
 

--- a/web/cgi-bin/registry/detoxlock.class.php
+++ b/web/cgi-bin/registry/detoxlock.class.php
@@ -520,8 +520,8 @@ class DetoxLock {
         array(
               'lockid' => $lid,
               'item' => $item,
-              'locked' => strftime('%Y-%m-%d %H:%M:%S', $created),
-              'expires' => strftime('%Y-%m-%d %H:%M:%S', $expiration),
+              'locked' => strftime('%Y-%m-%d %H:%M:%S UTC', $created),
+              'expires' => strftime('%Y-%m-%d %H:%M:%S UTC', $expiration),
               );
 
       if ($sites !== NULL)
@@ -529,7 +529,7 @@ class DetoxLock {
       if ($groups !== NULL)
         $datum['groups'] = $groups;
       if ($disabled !== NULL)
-        $datum['unlocked'] = strftime('%Y-%m-%d %H:%M:%S', $disabled);
+        $datum['unlocked'] = strftime('%Y-%m-%d %H:%M:%S UTC', $disabled);
       if ($comment !== NULL)
         $datum['comment'] = $comment;
 

--- a/web/cgi-bin/registry/requests.class.php
+++ b/web/cgi-bin/registry/requests.class.php
@@ -350,14 +350,14 @@ class Requests {
       'r.`group`',
       'r.`num_copies`',
       'r.`status`',
-      'r.`first_request_time`',
-      'r.`last_request_time`',
+      'UNIX_TIMESTAMP(r.`first_request_time`)',
+      'UNIX_TIMESTAMP(r.`last_request_time`)',
       'r.`request_count`',
       'r.`rejection_reason`',
       'a.`item`',
       'a.`site`',
       'a.`status`',
-      'a.`updated`'
+      'UNIX_TIMESTAMP(a.`updated`)'
     );
     if ($users !== NULL) {
       $fields[] = 'u.`name`';
@@ -440,8 +440,8 @@ class Requests {
           'group' => $group,
           'n' => $ncopy,
           'status' => $status,
-          'first_request' => $first_request,
-          'last_request' => $last_request,
+          'first_request' => strftime('%Y-%m-%d %H:%M:%S UTC', $first_request),
+          'last_request' => strftime('%Y-%m-%d %H:%M:%S UTC', $last_request),
           'request_count' => $request_count
         );
 
@@ -459,7 +459,7 @@ class Requests {
       }
 
       if ($astatus !== NULL)
-        $datum['copy'][] = array('item' => $aitem, 'site' => $asite, 'status' => $astatus, 'updated' => $atimestamp);
+        $datum['copy'][] = array('item' => $aitem, 'site' => $asite, 'status' => $astatus, 'updated' => strftime('%Y-%m-%d %H:%M:%S UTC', $atimestamp));
     }
 
     $stmt->close();
@@ -599,12 +599,12 @@ class Requests {
     $fields = array(
       'r.`id`',
       'r.`status`',
-      'r.`timestamp`',
+      'UNIX_TIMESTAMP(r.`timestamp`)',
       'r.`rejection_reason`',
       'a.`item`',
       'a.`site`',
       'a.`status`',
-      'a.`updated`'
+      'UNIX_TIMESTAMP(a.`updated`)'
     );
     if ($users !== NULL) {
       $fields[] = 'u.`name`';
@@ -687,7 +687,7 @@ class Requests {
           'request_id' => $rid,
           'item' => array(),
           'status' => $status,
-          'requested' => $timestamp
+          'requested' => strftime('%Y-%m-%d %H:%M:%S UTC', $timestamp)
         );
 
         $datum = &$data[$rid];
@@ -704,7 +704,7 @@ class Requests {
       }
 
       if ($astatus !== NULL)
-        $datum['deletion'][] = array('item' => $aitem, 'site' => $asite, 'status' => $astatus, 'updated' => $atimestamp);
+        $datum['deletion'][] = array('item' => $aitem, 'site' => $asite, 'status' => $astatus, 'updated' => strftime('%Y-%m-%d %H:%M:%S UTC', $atimestamp));
     }
 
     $stmt->close();

--- a/web/cgi-bin/registry/requests.php
+++ b/web/cgi-bin/registry/requests.php
@@ -23,7 +23,7 @@ include_once('requests.class.php');
 
 if (isset($_REQUEST['service'])) {
   $service = $_REQUEST['service'];
-  // $request['service'] is used to look up locks when command = list
+  unset($_REQUEST['service']);
 }
 else
   $service = 'user';


### PR DESCRIPTION
Reworked object deletions.
- delete_from() -> renamed to unlink_from() which is more accurage
- new functions delete_from() now does the deletion from persistency store (before we were using write_into with delete = True, which was a bit confusing)
- mysqlstore delete functions follow what unlink_from() does. This way, whatever gets unlinked in the subprocesses and gets reported back to the server will be properly deleted from the DB including all related objects.

Crucial bugfix in the updater. Hopefully the last missing piece. `blockreplicas` query with only `update_since=` gives us block replicas created since 1 day. We needed to explicitly add `create_since=0`.

Web updates. Some timestamps were in Boston time. Now changed to UTC.