### PR TITLE
Fixing detox logic

### DIFF
--- a/config/dealer_config.json
+++ b/config/dealer_config.json
@@ -73,8 +73,10 @@
           "max_dataset_size": 50.0,
           "max_cycle_volume": 5.0,
           "target_reasons": {
-            "dataset.name == /*/*/MINIAOD* and replica.num_full_disk_copy_common_owner < 3": 3,
-            "replica.num_full_disk_copy_common_owner < 2": 2
+            "dataset.name == /*/*/MINIAOD* and replica.num_full_disk_copy_common_owner < 3": 2,
+            "dataset.name == /*/*/MINIAOD* and replica.num_full_other_copy_common_owner < 2": 2,
+            "replica.num_full_disk_copy_common_owner < 2": 1,
+            "replica.num_full_other_copy_common_owner == 0": 1
           }
         }
       },

--- a/lib/dealer/plugins/balancer.py
+++ b/lib/dealer/plugins/balancer.py
@@ -96,7 +96,7 @@ class BalancingHandler(BaseHandler):
                     if replica in replica.site.partitions[partition].replicas:
                         num_nonpartial += 1
 
-                if num_nonpartial < num_rep:
+                if num_nonpartial <= num_rep:
                     LOG.debug('%s is a last copy at %s', ds_name, site.name)
                     last_copies[site].append(dataset)
 

--- a/lib/policy/variables.py
+++ b/lib/policy/variables.py
@@ -133,6 +133,22 @@ class ReplicaNumFullDiskCopyCommonOwner(DatasetReplicaAttr):
     
         return num
 
+class ReplicaNumFullOtherCopyCommonOwner(DatasetReplicaAttr):
+    def __init__(self):
+        DatasetReplicaAttr.__init__(self, Attr.NUMERIC_TYPE)
+
+    def _get(self, replica):
+        owners = set(br.group for br in replica.block_replicas)
+        dataset = replica.dataset
+        num = 0
+        for rep in dataset.replicas:
+            if rep.site is not replica.site and rep.site.status == Site.STAT_READY and rep.is_full():
+                rep_owners = set(br.group for br in rep.block_replicas)
+                if len(owners & rep_owners) != 0:
+                    num += 1
+    
+        return num
+
 class ReplicaEnforcerProtected(DatasetReplicaAttr):
     def __init__(self):
         DatasetReplicaAttr.__init__(self, Attr.BOOL_TYPE)
@@ -308,6 +324,7 @@ replica_variables = {
     'replica.first_block_created': ReplicaFirstBlockCreated(),
     'replica.num_access': DatasetAttr(Attr.NUMERIC_TYPE, dict_attr = 'num_access'),
     'replica.num_full_disk_copy_common_owner': ReplicaNumFullDiskCopyCommonOwner(),
+    'replica.num_full_other_copy_common_owner': ReplicaNumFullOtherCopyCommonOwner(),
     'replica.enforcer_protected': ReplicaEnforcerProtected(),
     'blockreplica.is_last_transfer_source': ReplicaIsLastSource(),
     'blockreplica.last_update': BlockReplicaAttr(Attr.TIME_TYPE, 'last_update'),

--- a/lib/source/impl/phedexsiteinfo.py
+++ b/lib/source/impl/phedexsiteinfo.py
@@ -85,7 +85,7 @@ class PhEDExSiteInfoSource(SiteInfoSource):
         site_list = []
 
         for entry in self._phedex.make_request('nodes'):
-            if not self.check_allowed_site(name):
+            if not self.check_allowed_site(entry['name']):
                 continue
 
             site_list.append(Site(entry['name'], host = entry['se'], storage_type = Site.storage_type_val(entry['kind']), backend = entry['technology']))


### PR DESCRIPTION
Policy lines
`Protect replica.num_full_disk_copy_common_owner < N`
would not let Detox dismiss partial replicas in cases like the following:
- N = 2
- there are dataset replicas r1 and r2, where r1 is partial and r2 is complete
Even though it's perfectly fine to dismiss r1, because the number of *full* copy is 1, it would be protected.

Fix is to add a variable num_full_other_copy_common_owner, which counts only the number of other replicas.