### PR TITLE
Logic error fix for detox

### DIFF
--- a/exec/track_phedex
+++ b/exec/track_phedex
@@ -40,6 +40,10 @@ dealer_config = Configuration(config.dealer_config).dealer
 
 LOG = make_standard_logger(config.log_level)
 
+## Parallelizer
+
+parallelizer = Map(config.parallel)
+
 ## Data source
 
 import dynamo.history.impl as history_impl
@@ -194,7 +198,7 @@ for site, request_ids in records.iteritems():
 
     dataset_details = []
 
-    status_list = Map(config.parallel).execute(get_copy_status, request_ids)
+    status_list = parallelizer.execute(get_copy_status, request_ids)
 
     for request_id, status in status_list:
         LOG.info('Transfer request ID: %d', request_id)


### PR DESCRIPTION
Key fix is line 321 of detox main.py. When there is a replica that is partially dismissed and partially protected, we were ignoring the entire replica in the later iterations even though the dismissed part should remain in the keep candidate. This caused big chunks of datasets to appear / disappear from sites depending on whether there were more than one detox iterations in the given cycle.

The rest of the changes are purely cosmetic.