### PR TITLE
Protect tape-requested

### DIFF
--- a/config/detox_config.json
+++ b/config/detox_config.json
@@ -71,6 +71,15 @@
         }
       },
       "BlockReplicaRelativeAge": {
+      },
+      "TapeCopyRequested": {
+        "phedex": {
+          "url_base": "https://cmsweb.cern.ch/phedex/datasvc/json/prod",
+          "dbs_url": "https://cmsweb.cern.ch/dbs/prod/global/DBSReader",
+          "auth_handler": "HTTPSCertKeyHandler",
+          "auth_handler_conf": {},
+          "num_attempts": 5
+        }        
       }
     }
   },
@@ -79,7 +88,7 @@
     "service": "dynamo",
     "app": "detox",
     "db_config": {
-      "config_file": "/etc/my.cnf.d/dynamo-read.cnf",
+      "config_file": "/etc/my.cnf.d/dynamo.cnf",
       "config_group": "mysql",
       "db": "dynamoregister"
     }

--- a/lib/policy/producers/__init__.py
+++ b/lib/policy/producers/__init__.py
@@ -16,6 +16,7 @@ from enforcerprotected import EnforcedProtectionTagger
 from datasetrelease import DatasetRelease
 from relativeage import BlockReplicaRelativeAge
 from dbs import CheckAllDBS
+from taperequest import TapeCopyRequested
 
 __all__ = [
     'CRABAccessHistory',
@@ -26,7 +27,8 @@ __all__ = [
     'EnforcedProtectionTagger',
     'DatasetRelease',
     'BlockReplicaRelativeAge',
-    'CheckAllDBS'
+    'CheckAllDBS',
+    'TapeCopyRequested'
 ]
 
 # Dictionary of registered producers

--- a/lib/policy/producers/taperequest.py
+++ b/lib/policy/producers/taperequest.py
@@ -24,7 +24,7 @@ class TapeCopyRequested(object):
             if site.storage_type != Site.TYPE_MSS:
                 continue
 
-            requests = phedex.make_request('transferrequests', ['node=' + site.name, 'approval=pending'])
+            requests = self._phedex.make_request('transferrequests', ['node=' + site.name, 'approval=pending'])
             for request in requests:
                 for dest in request['destinations']['node']:
                     if dest['name'] != site.name:

--- a/lib/policy/producers/taperequest.py
+++ b/lib/policy/producers/taperequest.py
@@ -1,0 +1,52 @@
+import re
+import collections
+import logging
+
+from dynamo.utils.interface.phedex import PhEDEx
+from dynamo.dataformat import Block, Site
+
+LOG = logging.getLogger(__name__)
+
+class TapeCopyRequested(object):
+    """
+    Check for pending tape transfer requests.
+    Sets one attr:
+      tape_copy_requested
+    """
+
+    produces = ['tape_copy_requested']
+
+    def __init__(self, config):
+        self._phedex = PhEDEx(config.phedex)
+
+    def load(self, inventory):
+        for site in inventory.sites.itervalues():
+            if site.storage_type != Site.TYPE_MSS:
+                continue
+
+            requests = phedex.make_request('transferrequests', ['node=' + site.name, 'approval=pending'])
+            for request in requests:
+                for dest in request['destinations']['node']:
+                    if dest['name'] != site.name:
+                        continue
+
+                    if 'decided_by' in dest:
+                        break
+
+                    for dataset_entry in request['data']['dbs']['dataset']:
+                        try:
+                            dataset = inventory.datasets[dataset_entry['name']]
+                        except KeyError:
+                            continue
+
+                        dataset.attr['tape_copy_requested'] = True
+
+                    for block_entry in request['data']['dbs']['block']:
+                        dataset_name, block_name = Block.from_full_name(block_entry['name'])
+                        try:
+                            dataset = inventory.datasets[dataset_name]
+                        except KeyError:
+                            continue
+
+                        # just label the entire dataset
+                        dataset.attr['tape_copy_requested'] = True

--- a/lib/policy/variables.py
+++ b/lib/policy/variables.py
@@ -321,7 +321,7 @@ replica_variables = {
     'dataset.name': DatasetName(),
     'dataset.status': DatasetStatus(),
     'dataset.on_tape': DatasetOnTape(),
-    'dataset.tape_copy_requested': DatasetAttr(Attr.BOOL_TYPE, dict_attr = 'tape_copy_requested', dicts_default = False),
+    'dataset.tape_copy_requested': DatasetAttr(Attr.BOOL_TYPE, dict_attr = 'tape_copy_requested', dict_default = False),
     'dataset.size': DatasetAttr(Attr.NUMERIC_TYPE, 'size'),
     'dataset.last_update': DatasetAttr(Attr.TIME_TYPE, 'last_update'),
     'dataset.last_access': DatasetAttr(Attr.TIME_TYPE, dict_attr = 'last_access', dict_default = 0),

--- a/lib/policy/variables.py
+++ b/lib/policy/variables.py
@@ -321,6 +321,7 @@ replica_variables = {
     'dataset.name': DatasetName(),
     'dataset.status': DatasetStatus(),
     'dataset.on_tape': DatasetOnTape(),
+    'dataset.tape_copy_requested': DatasetAttr(Attr.BOOL_TYPE, dict_attr = 'tape_copy_requested', dicts_default = False),
     'dataset.size': DatasetAttr(Attr.NUMERIC_TYPE, 'size'),
     'dataset.last_update': DatasetAttr(Attr.TIME_TYPE, 'last_update'),
     'dataset.last_access': DatasetAttr(Attr.TIME_TYPE, dict_attr = 'last_access', dict_default = 0),


### PR DESCRIPTION
Just realized we have a hole in the protection logic. Unified unlocks datasets as soon as it makes tape transfer requests. Dynamo was supposed to take over the protection by looking at the tape subscription status. However, at most of the T1 sites, the tape write request are approved by the site admins manually and there can be multiple days of delay in some cases.
Practically, this only seems to matter for DQMIO datasets because the other datasets will have at least one AnalysisOps disk subscription in addition to the tape request.
This PR adds a new variable that can be used for protections against such delays.